### PR TITLE
scikit-image was missing from pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python modules to be installed. Advice : use conda env
 ```
 conda create -n nn python=3.5
 source activate nn
-pip install netCDF4 h5py numpy scipy matplotlib xarray tensorflow keras scikit-learn scikit-gstat
+pip install netCDF4 h5py numpy scipy matplotlib xarray tensorflow keras scikit-learn scikit-gstat scikit-image
 ```
 Regarding tensorflow, you can have a more specific installation looking at the website:
 <https://www.tensorflow.org/install/>


### PR DESCRIPTION
When I followed the README, I got a missing library error for skimage